### PR TITLE
chore(lint): remove all TypeScript-related rules and references

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -64,14 +64,6 @@ export default [
       // Variables y declaraciones
       'no-unused-expressions': 'error',
       'no-unused-vars': 'off',
-      '@typescript-eslint/no-unused-vars': [
-        'error',
-        {
-          argsIgnorePattern: '^_',
-          varsIgnorePattern: '^_',
-          ignoreRestSiblings: true,
-        },
-      ],
       'no-var': 'error',
       'prefer-const': 'error',
 


### PR DESCRIPTION
- Delete @typescript-eslint/no-unused-vars rule from ESLint config
- Ensure no TypeScript dependencies, configs, or extensions remain
- Project is now fully JavaScript-only and CI/CD is TypeScript-free